### PR TITLE
clarify which resolutions are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ A macro for the Roblox game "Grow a Garden"
  - After downloading, extract the ZIP file to your desired directory
 
 Before starting the macro:
-- ensure you **extracted** the macro file
-- **don't** go full screen, be in windowed fullscreen
+- Ensure you **extracted** the macro file
+- **Don't** go full screen, be in windowed fullscreen
+- Make sure your resolution is set to 1920x1080 or 2560x1440
 - Set your roblox camera mode to the following --> **default(classic)**
-- put "Recall Wrench" in the **2nd hot bar slot** --> macro may bug out and not automatically do it
-- have 5-10 things in your hotbar
-- make sure UI Navigation is turned **ON** in your Roblox settings
-- unequip your **“grey mouse” pet** if you have some equipped since they give you a speed bonus that will break the macro
+- Put "Recall Wrench" in the **2nd hot bar slot** --> macro may bug out and not automatically do it
+- Have 5-10 things in your hotbar
+- Make sure UI Navigation is turned **ON** in your Roblox settings
+- Unequip your **“grey mouse” pet** if you have some equipped since they give you a speed bonus that will break the macro
 
 ## Features
 Virage Grow A Garden Macro has a couple of different features it is capable of. These include:


### PR DESCRIPTION
i had problems with this macro until i took a look in `Main.ahk` and found the following lines:
```
global scrollCounts_1080p, scrollCounts_1440p_100, scrollCounts_1440p_125
...
global gearScroll_1080p, toolScroll_1440p_100, toolScroll_1440p_125
```

when i realized that i had an unsupported resolution. when changing one of the monitors to 1920x1080 the macro started to work as intended by going into the gear shop correctly, instead of opening the in-game shop.

the PR adds the dependency on resolution as one of the items in "Before starting the macro" list. the resolution requirement was not listed in any instructions i could find.